### PR TITLE
address ActiveRecord deprecations in Rails 4.0

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,6 +1,6 @@
 Spree::Product.class_eval do
   def self.find_by_array_of_ids(ids)
-    products = Spree::Product.find(:all, :conditions => ["id IN (?)", ids])
+    products = Spree::Product.where('id IN (?)', ids)
     ids.map{|id| products.detect{|p| p.id == id.to_i}}.compact
   end
 end


### PR DESCRIPTION
This backports one of the nice syntax changes from the large 9f7ed58fef0c2be85cce4cc4da96a6db4c9a8886 commit to the `2-2-stable` branch, in order to address a deprecation warning currently triggered by the `2-1-stable` branch.