### PR TITLE
bump version to 3.2.0.alpha

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-branch = '3-1-stable'
+branch = 'master'
 gem 'spree', github: 'spree/spree', branch: branch
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: branch
 

--- a/lib/spree_recently_viewed/version.rb
+++ b/lib/spree_recently_viewed/version.rb
@@ -9,9 +9,9 @@ module SpreeRecentlyViewed
 
   module VERSION
     MAJOR = 3
-    MINOR = 1
+    MINOR = 2
     TINY  = 0
-    PRE   = nil
+    PRE   = 'alpha'.freeze
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
   end

--- a/spree_recently_viewed.gemspec
+++ b/spree_recently_viewed.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = false
 
-  s.add_runtime_dependency 'spree_core', '~> 3.1.0.beta'
+  s.add_runtime_dependency 'spree_core', '~> 3.2.0.alpha'
 
   s.add_development_dependency 'rspec-rails', '~> 3.2.0'
   s.add_development_dependency 'factory_girl', '~> 4.4'


### PR DESCRIPTION
- bump version to 3.2.0.alpha
- change spree dependency version to 3.2.0.alpha
- change spree branch to master