### PR TITLE
Removed extra map operation on result

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,8 +1,7 @@
 module Spree
   Product.class_eval do
     def self.find_by_array_of_ids(ids)
-      products = Spree::Product.where('id IN (?)', ids)
-      ids.map { |id| products.detect { |product| product.id == id.to_i } }.compact
+      where(id: ids)
     end
   end
 end


### PR DESCRIPTION
```ids.map { |id| products.detect { |product| product.id == id.to_i } }.compact``` is resulting same result of ```products = Spree::Product.where('id IN (?)', ids)```.