### PR TITLE
Set spree_core to >= 3.1.0 and < 4.0 versions

### DIFF
--- a/spree_recently_viewed.gemspec
+++ b/spree_recently_viewed.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = false
 
-  s.add_runtime_dependency 'spree_core', '~> 3.2.0.alpha'
+  s.add_runtime_dependency 'spree_core', '>= 3.1.0', '< 4.0'
 
   s.add_development_dependency 'rspec-rails', '~> 3.2.0'
   s.add_development_dependency 'factory_girl', '~> 4.4'


### PR DESCRIPTION
This PR changes the version of `spree_core` in gemspec to point at `>= 3.1.0` and `< 4.0`.
