### PR TITLE
update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This extension maintains and displays a list of the products a user has recently
 
 3. Copy & run migrations
   ```ruby
-  bundle exec rails g spree:recently_viewed:install
+  bundle exec rails g spree_recently_viewed:install
   ```
 
 4. Restart your server


### PR DESCRIPTION
I got this error when I did `bundle exec rails g spree:recently_viewed:install`

> Could not find generator 'spree:recently_viewed:install'. Maybe you meant 'spree_recently_viewed:install'.
Run `rails generate --help` for more options.