### PR TITLE
Added Deface as dependency

### DIFF
--- a/spree_recently_viewed.gemspec
+++ b/spree_recently_viewed.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.has_rdoc = false
 
   s.add_runtime_dependency 'spree_core', '>= 3.1.0', '< 4.0'
+  s.add_dependency 'deface', '~> 1.0'
 
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'factory_bot', '~> 4.7'


### PR DESCRIPTION
Since Spree 4.0 [doesn't require deface](https://github.com/spree/spree/pull/9394) we need to require it here